### PR TITLE
v4

### DIFF
--- a/assert.h
+++ b/assert.h
@@ -3,6 +3,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdbool.h>
 #include <assert.h>
 
 

--- a/assert.h
+++ b/assert.h
@@ -23,23 +23,11 @@
 
 
 
-#ifdef __linux__
-
-#define __FN __ASSERT_FUNCTION
-
-#elif defined __APPLE__
-
-#define __FN __func__
-
-#endif
-
-
-
 #define assert(COND)                \
     if(!(COND))                     \
     {                               \
         fprintf(stderr, "\n\n");    \
-        fprintf(stderr, "%s:%d: %s: Assertion '%s' failed\n", __FILE__, __LINE__, __FN, #COND);  \
+        fprintf(stderr, "%s:%d: %s: Assertion '%s' failed\n", __FILE__, __LINE__, __func__, #COND); \
         fprintf(stderr, "\n");      \
         TRIGGER_SANITIZER           \
         exit(EXIT_FAILURE);         \

--- a/assert.h
+++ b/assert.h
@@ -3,7 +3,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdbool.h>
 #include <assert.h>
 
 

--- a/assert.h
+++ b/assert.h
@@ -1,7 +1,7 @@
 #ifndef __ASSERT_H__
 #define __ASSERT_H__
 
-#include <stdio.h>
+#include <stdio.h> // IWYU pragma: keep
 #include <stdlib.h>
 #include <assert.h>
 

--- a/fork.h
+++ b/fork.h
@@ -5,13 +5,15 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+#include "assert.h"
+
 __attribute__((unused))
 static pid_t fork_safe(void)
 {
     pid_t pid = fork();
     if(pid < 0)
     {
-        exit(EXIT_FAILURE);
+        assert(false);
     }
 
     return pid;
@@ -24,7 +26,7 @@ static pid_t waitpid_safe(pid_t pid, int *status)
     pid_t pid_return = waitpid(pid, &_status, 0);
     if(pid_return <= 0)
     {
-        exit(EXIT_FAILURE);
+        assert(false);
     }
 
     if(status)

--- a/fork.h
+++ b/fork.h
@@ -11,23 +11,16 @@
 static pid_t fork_safe()
 {
     pid_t pid = fork();
-    if(pid < 0)
-    {
-        assert(false);
-    }
-
+    assert(pid >= 0);
     return pid;
 }
 
 [[nodiscard, maybe_unused]]
-static pid_t waitpid_safe(pid_t pid, int *status)
+static pid_t _waitpid_safe_internal(pid_t pid, int *status)
 {
     int _status;
     pid_t pid_return = waitpid(pid, &_status, 0);
-    if(pid_return <= 0)
-    {
-        assert(false);
-    }
+    assert(pid_return >= 0);
 
     if(status)
     {
@@ -35,6 +28,19 @@ static pid_t waitpid_safe(pid_t pid, int *status)
     }
 
     return pid_return;
+}
+
+[[maybe_unused]]
+static void waitpid_safe(pid_t pid, int *status)
+{
+    assert(pid > 0);
+    (void)_waitpid_safe_internal(pid, status);
+}
+
+[[nodiscard, maybe_unused]]
+static pid_t waitpid_child_safe(int *status)
+{
+    return _waitpid_safe_internal(0, status);
 }
 
 #endif

--- a/fork.h
+++ b/fork.h
@@ -15,7 +15,7 @@ static pid_t fork_safe()
     return pid;
 }
 
-[[nodiscard, maybe_unused]]
+[[maybe_unused]]
 static pid_t waitpid_safe(pid_t pid, int *status)
 {
     int _status;

--- a/fork.h
+++ b/fork.h
@@ -8,7 +8,7 @@
 #include "assert.h"
 
 [[nodiscard, maybe_unused]]
-static pid_t fork_safe(void)
+static pid_t fork_safe()
 {
     pid_t pid = fork();
     if(pid < 0)

--- a/fork.h
+++ b/fork.h
@@ -16,7 +16,7 @@ static pid_t fork_safe()
 }
 
 [[nodiscard, maybe_unused]]
-static pid_t _waitpid_safe_internal(pid_t pid, int *status)
+static pid_t waitpid_safe(pid_t pid, int *status)
 {
     int _status;
     pid_t pid_return = waitpid(pid, &_status, 0);
@@ -28,19 +28,6 @@ static pid_t _waitpid_safe_internal(pid_t pid, int *status)
     }
 
     return pid_return;
-}
-
-[[maybe_unused]]
-static void waitpid_safe(pid_t pid, int *status)
-{
-    assert(pid > 0);
-    (void)_waitpid_safe_internal(pid, status);
-}
-
-[[nodiscard, maybe_unused]]
-static pid_t waitpid_child_safe(int *status)
-{
-    return _waitpid_safe_internal(0, status);
 }
 
 #endif

--- a/fork.h
+++ b/fork.h
@@ -7,7 +7,7 @@
 
 #include "assert.h"
 
-__attribute__((unused))
+[[nodiscard, maybe_unused]]
 static pid_t fork_safe(void)
 {
     pid_t pid = fork();
@@ -19,7 +19,7 @@ static pid_t fork_safe(void)
     return pid;
 }
 
-__attribute__((unused))
+[[nodiscard, maybe_unused]]
 static pid_t waitpid_safe(pid_t pid, int *status)
 {
     int _status;

--- a/fork.h
+++ b/fork.h
@@ -1,7 +1,6 @@
 #ifndef __MACROS_FORK_H__
 #define __MACROS_FORK_H__
 
-#include <stdlib.h>
 #include <sys/wait.h>
 #include <unistd.h>
 

--- a/static.h
+++ b/static.h
@@ -1,0 +1,14 @@
+#ifndef __STATIC_H__
+#define __STATIC_H__
+
+#ifdef DEBUG
+
+#define STATIC
+
+#else // DEBUG
+
+#define STATIC static
+
+#endif // DEBUG
+
+#endif // __STATIC_H__

--- a/stdbit.h
+++ b/stdbit.h
@@ -1,10 +1,12 @@
 #ifndef CLU_STDBIT_FIX_H
 #define CLU_STDBIT_FIX_H
 
+// 1. If the system actually has the file (Linux/Future Mac), use it.
+#if __has_include(<stdbit.h>)
+    #include <stdbit.h>
+
 // 2. Otherwise, map the C23 standard names to Clang builtins
 #else // has stdbit.h
-    #include <stdint.h>
-
     // Count Leading Zeros (clz)
     #define stdc_trailing_zeros(x)                  \
         ((unsigned int)_Generic((x),                \

--- a/stdbit.h
+++ b/stdbit.h
@@ -1,10 +1,6 @@
 #ifndef CLU_STDBIT_FIX_H
 #define CLU_STDBIT_FIX_H
 
-// 1. If the system actually has the file (Linux/Future Mac), use it.
-#if defined(__has_include) && __has_include(<stdbit.h>)
-    #include <stdbit.h>
-
 // 2. Otherwise, map the C23 standard names to Clang builtins
 #else // has stdbit.h
     #include <stdint.h>

--- a/test.h
+++ b/test.h
@@ -31,7 +31,7 @@
     }
 
 __attribute__((format(printf, 4, 5)))
-void test_log_error(uint64_t __tag, uint64_t line, const char func[], const char format[], ...)
+static void test_log_error(uint64_t __tag, uint64_t line, const char func[], const char format[], ...)
 {
     va_list args;
     va_start(args, format);
@@ -42,7 +42,8 @@ void test_log_error(uint64_t __tag, uint64_t line, const char func[], const char
 }
 
 // returns true if main process
-bool start_case(uint64_t __tag, uint64_t line, const char func[], bool show, uint64_t timeout_ms)
+__attribute__((unused))
+static bool start_case(uint64_t __tag, uint64_t line, const char func[], bool show, uint64_t timeout_ms)
 {
     if(show)
     {
@@ -134,7 +135,8 @@ bool start_case(uint64_t __tag, uint64_t line, const char func[], bool show, uin
         }                       \
     }
 
-pid_t start_revert(uint64_t __tag, uint64_t line, const char func[])
+__attribute__((unused))
+static pid_t start_revert(uint64_t __tag, uint64_t line, const char func[])
 {
     pid_t pid = fork();
     if(pid < 0)

--- a/test.h
+++ b/test.h
@@ -23,7 +23,7 @@
         if(__test_memory)           \
             TEST_ASSERT_MEM_EMPTY   \
         if(!__is_main_process)      \
-            assert(false);          \
+            exit(EXIT_SUCCESS);     \
     }
 
 __attribute__((format(printf, 4, 5)))
@@ -68,7 +68,7 @@ bool start_case(uint64_t __tag, uint64_t line, const char func[], bool show, uin
                 .tv_nsec = (long)((timeout_ms % 1000) * 1000000)
             };
             nanosleep(&spec, NULL);
-            assert(false);
+            exit(EXIT_SUCCESS);
         }
 
         pid_t pid_return = waitpid_safe(0, &status);
@@ -94,7 +94,7 @@ bool start_case(uint64_t __tag, uint64_t line, const char func[], bool show, uin
     {
         test_log_error(__tag, line, func, "ERROR IN TEST EXECUTION ");
     }
-    assert(false);
+    exit(EXIT_SUCCESS);
 }
 
 
@@ -137,7 +137,7 @@ pid_t start_revert(uint64_t __tag, uint64_t line, const char func[])
         )
         {
             printf("\n\n\tERROR REDIRECTING STD BUFFERS\n\n");
-            assert(false);
+            exit(EXIT_SUCCESS);
         }
         struct timespec spec = (struct timespec) {0};
         nanosleep(&spec, NULL);
@@ -151,7 +151,7 @@ pid_t start_revert(uint64_t __tag, uint64_t line, const char func[])
         {
 
 #define TEST_REVERT_CLOSE       \
-            assert(false);      \
+            exit(EXIT_SUCCESS); \
         }                       \
         __test_memory = false;  \
     }

--- a/test.h
+++ b/test.h
@@ -121,11 +121,11 @@ bool start_case(uint64_t __tag, uint64_t line, const char func[], bool show, uin
         }               \
     }
 
-#define TEST_FUZZ_CASE_OPEN(TAG, RUNS)                      \
-    {                                                       \
-        for(uint64_t _i=0; _i<RUNS; _i++)                   \
-        {                                                   \
-            TEST_CASE_OPEN((uint64_t)(TAG) * 1000000 + _i)  \
+#define TEST_FUZZ_CASE_OPEN(TAG, RUNS)                                  \
+    {                                                                   \
+        for(uint64_t _i=0; _i<RUNS; _i++)                               \
+        {                                                               \
+            TEST_CASE_OPEN_TIMEOUT((uint64_t)(TAG) * 1000000 + _i, 0)   \
             {
 
 #define TEST_FUZZ_CASE_CLOSE    \

--- a/test.h
+++ b/test.h
@@ -23,7 +23,7 @@
         if(__test_memory)           \
             TEST_ASSERT_MEM_EMPTY   \
         if(!__is_main_process)      \
-            exit(EXIT_SUCCESS);     \
+            assert(false);          \
     }
 
 __attribute__((format(printf, 4, 5)))
@@ -34,7 +34,7 @@ void test_log_error(uint64_t __tag, uint64_t line, const char func[], const char
     printf("\n\n\tERROR TEST\t| l: " U64P() " | %s " U64P() " | ", line, func, __tag);
     vprintf(format, args);
     printf("\n\n");
-    exit(EXIT_FAILURE);
+    assert(false);
 }
 
 // returns true if main process
@@ -68,7 +68,7 @@ bool start_case(uint64_t __tag, uint64_t line, const char func[], bool show, uin
                 .tv_nsec = (long)((timeout_ms % 1000) * 1000000)
             };
             nanosleep(&spec, NULL);
-            exit(EXIT_SUCCESS);
+            assert(false);
         }
 
         pid_t pid_return = waitpid_safe(0, &status);
@@ -94,7 +94,7 @@ bool start_case(uint64_t __tag, uint64_t line, const char func[], bool show, uin
     {
         test_log_error(__tag, line, func, "ERROR IN TEST EXECUTION ");
     }
-    exit(EXIT_SUCCESS);
+    assert(false);
 }
 
 
@@ -137,7 +137,7 @@ pid_t start_revert(uint64_t __tag, uint64_t line, const char func[])
         )
         {
             printf("\n\n\tERROR REDIRECTING STD BUFFERS\n\n");
-            exit(EXIT_SUCCESS);
+            assert(false);
         }
         struct timespec spec = (struct timespec) {0};
         nanosleep(&spec, NULL);
@@ -151,7 +151,7 @@ pid_t start_revert(uint64_t __tag, uint64_t line, const char func[])
         {
 
 #define TEST_REVERT_CLOSE       \
-            exit(EXIT_SUCCESS); \
+            assert(false);      \
         }                       \
         __test_memory = false;  \
     }

--- a/test.h
+++ b/test.h
@@ -21,9 +21,13 @@
 
 #define TEST_FN_CLOSE               \
         if(__test_memory)           \
+        {                           \
             TEST_ASSERT_MEM_EMPTY   \
+        }                           \
         if(!__is_main_process)      \
+        {                           \
             exit(EXIT_SUCCESS);     \
+        }                           \
     }
 
 __attribute__((format(printf, 4, 5)))
@@ -41,7 +45,9 @@ void test_log_error(uint64_t __tag, uint64_t line, const char func[], const char
 bool start_case(uint64_t __tag, uint64_t line, const char func[], bool show, uint64_t timeout_ms)
 {
     if(show)
+    {
         printf("\n\t\t%s " U64P(2) "\t\t", func, __tag);
+    }
 
     pid_t pid = fork_safe();
     if(pid)
@@ -54,7 +60,9 @@ bool start_case(uint64_t __tag, uint64_t line, const char func[], bool show, uin
 
     pid_t pid_test = fork_safe();
     if(pid_test == 0)
+    {   
         return false;
+    }
 
     int status;
     if(timeout_ms)
@@ -111,6 +119,19 @@ bool start_case(uint64_t __tag, uint64_t line, const char func[], bool show, uin
 
 #define TEST_CASE_CLOSE \
         }               \
+    }
+
+#define TEST_FUZZ_CASE_OPEN(COUNT, TAG)     \
+    {                                       \
+        for(uint64_t _i=0; _i<COUNT; _i++)  \
+        {                                   \
+            TEST_CASE_OPEN(TAG)             \
+            {
+
+#define TEST_FUZZ_CASE_CLOSE    \
+            }                   \
+            TEST_CASE_CLOSE     \
+        }                       \
     }
 
 pid_t start_revert(uint64_t __tag, uint64_t line, const char func[])

--- a/test.h
+++ b/test.h
@@ -121,11 +121,11 @@ bool start_case(uint64_t __tag, uint64_t line, const char func[], bool show, uin
         }               \
     }
 
-#define TEST_FUZZ_CASE_OPEN(COUNT, TAG)     \
-    {                                       \
-        for(uint64_t _i=0; _i<COUNT; _i++)  \
-        {                                   \
-            TEST_CASE_OPEN(TAG)             \
+#define TEST_FUZZ_CASE_OPEN(RUNS, TAG)          \
+    {                                           \
+        for(uint64_t _i=0; _i<RUNS; _i++)       \
+        {                                       \
+            TEST_CASE_OPEN(TAG * 1000000 + _i)  \
             {
 
 #define TEST_FUZZ_CASE_CLOSE    \

--- a/test.h
+++ b/test.h
@@ -121,11 +121,11 @@ bool start_case(uint64_t __tag, uint64_t line, const char func[], bool show, uin
         }               \
     }
 
-#define TEST_FUZZ_CASE_OPEN(RUNS, TAG)          \
-    {                                           \
-        for(uint64_t _i=0; _i<RUNS; _i++)       \
-        {                                       \
-            TEST_CASE_OPEN(TAG * 1000000 + _i)  \
+#define TEST_FUZZ_CASE_OPEN(TAG, RUNS)                      \
+    {                                                       \
+        for(uint64_t _i=0; _i<RUNS; _i++)                   \
+        {                                                   \
+            TEST_CASE_OPEN((uint64_t)(TAG) * 1000000 + _i)  \
             {
 
 #define TEST_FUZZ_CASE_CLOSE    \

--- a/test.h
+++ b/test.h
@@ -53,7 +53,7 @@ static bool start_case(uint64_t __tag, uint64_t line, const char func[], bool sh
     if(pid)
     {
         int status;
-        (void)waitpid_safe(pid, &status);
+        waitpid_safe(pid, &status);
         assert(status == EXIT_SUCCESS);
         return true;
     }
@@ -79,7 +79,7 @@ static bool start_case(uint64_t __tag, uint64_t line, const char func[], bool sh
             exit(EXIT_SUCCESS);
         }
 
-        pid_t pid_return = waitpid_child_safe(&status);
+        pid_t pid_return = waitpid_safe(0, &status);
         if(pid_return == pid_timeout)
         {
             kill(pid_test, SIGKILL);
@@ -95,7 +95,7 @@ static bool start_case(uint64_t __tag, uint64_t line, const char func[], bool sh
     }
     else
     {
-        (void)waitpid_safe(pid_test, &status);
+        waitpid_safe(pid_test, &status);
     }
 
     if(status != EXIT_SUCCESS)
@@ -145,7 +145,7 @@ static pid_t start_revert(uint64_t __tag, uint64_t line, const char func[])
     if(pid)
     {
         int status;
-        (void)waitpid_safe(pid, &status);
+        waitpid_safe(pid, &status);
         if(status == EXIT_SUCCESS)
         {
             test_log_error(__tag, line, func, "TEST EXPECTED TO REVERT BUT DIDN'T");

--- a/test.h
+++ b/test.h
@@ -53,7 +53,7 @@ static bool start_case(uint64_t __tag, uint64_t line, const char func[], bool sh
     if(pid)
     {
         int status;
-        waitpid_safe(pid, &status);
+        (void)waitpid_safe(pid, &status);
         assert(status == EXIT_SUCCESS);
         return true;
     }

--- a/test.h
+++ b/test.h
@@ -60,7 +60,7 @@ static bool start_case(uint64_t __tag, uint64_t line, const char func[], bool sh
 
     pid_t pid_test = fork_safe();
     if(pid_test == 0)
-    {   
+    {
         return false;
     }
 

--- a/test.h
+++ b/test.h
@@ -41,7 +41,7 @@ static void test_log_error(uint64_t __tag, uint64_t line, const char func[], con
 }
 
 // returns true if main process
-[[maybe_unused]]
+[[nodiscard]]
 static bool start_case(uint64_t __tag, uint64_t line, const char func[], bool show, uint64_t timeout_ms)
 {
     if(show)
@@ -53,7 +53,7 @@ static bool start_case(uint64_t __tag, uint64_t line, const char func[], bool sh
     if(pid)
     {
         int status;
-        (void)waitpid_safe(pid, &status);
+        waitpid_safe(pid, &status);
         assert(status == EXIT_SUCCESS);
         return true;
     }
@@ -79,7 +79,7 @@ static bool start_case(uint64_t __tag, uint64_t line, const char func[], bool sh
             exit(EXIT_SUCCESS);
         }
 
-        pid_t pid_return = waitpid_safe(0, &status);
+        pid_t pid_return = waitpid_child_safe(&status);
         if(pid_return == pid_timeout)
         {
             kill(pid_test, SIGKILL);

--- a/test.h
+++ b/test.h
@@ -1,7 +1,6 @@
 #ifndef __TEST_H__
 #define __TEST_H__
 
-#include <stdbool.h>
 #include <signal.h>
 #include <stdarg.h>
 #include <time.h>
@@ -30,7 +29,7 @@
         }                           \
     }
 
-__attribute__((format(printf, 4, 5)))
+[[noreturn, gnu::format(printf, 4, 5)]]
 static void test_log_error(uint64_t __tag, uint64_t line, const char func[], const char format[], ...)
 {
     va_list args;
@@ -42,7 +41,7 @@ static void test_log_error(uint64_t __tag, uint64_t line, const char func[], con
 }
 
 // returns true if main process
-__attribute__((unused))
+[[maybe_unused]]
 static bool start_case(uint64_t __tag, uint64_t line, const char func[], bool show, uint64_t timeout_ms)
 {
     if(show)
@@ -54,7 +53,7 @@ static bool start_case(uint64_t __tag, uint64_t line, const char func[], bool sh
     if(pid)
     {
         int status;
-        waitpid_safe(pid, &status);
+        (void)waitpid_safe(pid, &status);
         assert(status == EXIT_SUCCESS);
         return true;
     }
@@ -76,7 +75,7 @@ static bool start_case(uint64_t __tag, uint64_t line, const char func[], bool sh
                 .tv_sec = (long)(timeout_ms / 1000),
                 .tv_nsec = (long)((timeout_ms % 1000) * 1000000)
             };
-            nanosleep(&spec, NULL);
+            nanosleep(&spec, nullptr);
             exit(EXIT_SUCCESS);
         }
 
@@ -96,7 +95,7 @@ static bool start_case(uint64_t __tag, uint64_t line, const char func[], bool sh
     }
     else
     {
-        waitpid_safe(pid_test, &status);
+        (void)waitpid_safe(pid_test, &status);
     }
 
     if(status != EXIT_SUCCESS)
@@ -135,7 +134,7 @@ static bool start_case(uint64_t __tag, uint64_t line, const char func[], bool sh
         }                       \
     }
 
-__attribute__((unused))
+[[maybe_unused]]
 static pid_t start_revert(uint64_t __tag, uint64_t line, const char func[])
 {
     pid_t pid = fork();
@@ -146,7 +145,7 @@ static pid_t start_revert(uint64_t __tag, uint64_t line, const char func[])
     if(pid)
     {
         int status;
-        waitpid_safe(pid, &status);
+        (void)waitpid_safe(pid, &status);
         if(status == EXIT_SUCCESS)
         {
             test_log_error(__tag, line, func, "TEST EXPECTED TO REVERT BUT DIDN'T");
@@ -155,15 +154,15 @@ static pid_t start_revert(uint64_t __tag, uint64_t line, const char func[])
     else
     {
         if(
-            freopen("/dev/null", "w", stderr) == NULL ||
-            freopen("/dev/null", "w", stdout) == NULL
+            freopen("/dev/null", "w", stderr) == nullptr ||
+            freopen("/dev/null", "w", stdout) == nullptr
         )
         {
             printf("\n\n\tERROR REDIRECTING STD BUFFERS\n\n");
             exit(EXIT_SUCCESS);
         }
-        struct timespec spec = (struct timespec) {0};
-        nanosleep(&spec, NULL);
+        struct timespec spec = {};
+        nanosleep(&spec, nullptr);
     }
     return pid;
 }

--- a/test.h
+++ b/test.h
@@ -9,44 +9,54 @@
 #include "fork.h"
 #include "uint.h"
 
+constexpr uint64_t TEST_MS_PER_SEC = 1000;
+constexpr uint64_t TEST_NS_PER_MS = 1000000;
+constexpr uint64_t TEST_FUZZ_TAG_MULTIPLIER = 1000000;
+
 #define TEST_LIB printf("\n%s\t\t", __func__);
 
 #define TEST_FN_OPEN                    \
     {                                   \
         printf("\n\t%s\t\t", __func__); \
-        bool __is_main_process = true;  \
-        bool __test_memory = true;      \
-        uint64_t __tag = 0;
+        bool _is_main_process = true;   \
+        bool _test_memory = true;       \
+        uint64_t _tag = 0;
 
 #define TEST_FN_CLOSE               \
-        if(__test_memory)           \
+        if(_test_memory)            \
         {                           \
             TEST_ASSERT_MEM_EMPTY   \
         }                           \
-        if(!__is_main_process)      \
+        if(!_is_main_process)       \
         {                           \
             exit(EXIT_SUCCESS);     \
         }                           \
     }
 
 [[noreturn, gnu::format(printf, 4, 5)]]
-static void test_log_error(uint64_t __tag, uint64_t line, const char func[], const char format[], ...)
+static void test_log_error(
+    uint64_t _tag,
+    const char func[],
+    uint64_t line,
+    const char format[],
+    ...
+)
 {
     va_list args;
     va_start(args, format);
-    printf("\n\n\tERROR TEST\t| l: " U64P() " | %s " U64P() " | ", line, func, __tag);
+    printf("\n\n\tERROR TEST\t| f: %s | l: " U64P() " | tag: " U64P() " | ", func, line, _tag);
     vprintf(format, args);
     printf("\n\n");
     assert(false);
 }
 
 // returns true if main process
-[[nodiscard]]
-static bool start_case(uint64_t __tag, uint64_t line, const char func[], bool show, uint64_t timeout_ms)
+[[nodiscard, maybe_unused]]
+static bool start_case(uint64_t _tag, uint64_t line, const char func[], bool show, uint64_t timeout_ms)
 {
     if(show)
     {
-        printf("\n\t\t%s " U64P(2) "\t\t", func, __tag);
+        printf("\n\t\t%s " U64P(2) "\t\t", func, _tag);
     }
 
     pid_t pid = fork_safe();
@@ -72,8 +82,8 @@ static bool start_case(uint64_t __tag, uint64_t line, const char func[], bool sh
         {
             struct timespec spec = (struct timespec)
             {
-                .tv_sec = (long)(timeout_ms / 1000),
-                .tv_nsec = (long)((timeout_ms % 1000) * 1000000)
+                .tv_sec = (long)(timeout_ms / TEST_MS_PER_SEC),
+                .tv_nsec = (long)((timeout_ms % TEST_MS_PER_SEC) * TEST_NS_PER_MS)
             };
             nanosleep(&spec, nullptr);
             exit(EXIT_SUCCESS);
@@ -83,12 +93,12 @@ static bool start_case(uint64_t __tag, uint64_t line, const char func[], bool sh
         if(pid_return == pid_timeout)
         {
             kill(pid_test, SIGKILL);
-            test_log_error(__tag, line, func, "TEST TIMEOUT");
+            test_log_error(_tag, func, line, "TEST TIMEOUT");
         }
 
         if(pid_return != pid_test)
         {
-            test_log_error(__tag, line, func, "INVALID PID CAUGHT %d", pid_return);
+            test_log_error(_tag, func, line, "INVALID PID CAUGHT %d", pid_return);
         }
 
         kill(pid_timeout, SIGKILL);
@@ -100,19 +110,19 @@ static bool start_case(uint64_t __tag, uint64_t line, const char func[], bool sh
 
     if(status != EXIT_SUCCESS)
     {
-        test_log_error(__tag, line, func, "ERROR IN TEST EXECUTION ");
+        test_log_error(_tag, func, line, "ERROR IN TEST EXECUTION ");
     }
     exit(EXIT_SUCCESS);
 }
 
 
 
-#define TEST_CASE_OPEN_TIMEOUT(TAG, TIMEOUT)                                        \
-    if(__is_main_process)                                                           \
-    {                                                                               \
-        __tag = (uint64_t)(TAG);                                                    \
-        __is_main_process = start_case(__tag, __LINE__, __func__, show, TIMEOUT);   \
-        if(!__is_main_process)                                                      \
+#define TEST_CASE_OPEN_TIMEOUT(TAG, TIMEOUT)                                    \
+    if(_is_main_process)                                                        \
+    {                                                                           \
+        _tag = (uint64_t)(TAG);                                                 \
+        _is_main_process = start_case(_tag, __LINE__, __func__, show, TIMEOUT); \
+        if(!_is_main_process)                                                   \
         {
 
 #define TEST_CASE_OPEN(TAG) TEST_CASE_OPEN_TIMEOUT(TAG, TEST_CASE_TIMEOUT_MS)
@@ -121,11 +131,17 @@ static bool start_case(uint64_t __tag, uint64_t line, const char func[], bool sh
         }               \
     }
 
-#define TEST_FUZZ_CASE_OPEN(TAG, RUNS)                                  \
-    {                                                                   \
-        for(uint64_t _i=0; _i<RUNS; _i++)                               \
-        {                                                               \
-            TEST_CASE_OPEN_TIMEOUT((uint64_t)(TAG) * 1000000 + _i, 0)   \
+[[maybe_unused]]
+static uint64_t tag_fuzz_get(uint64_t _tag, uint64_t _i)
+{
+    return (_tag * TEST_FUZZ_TAG_MULTIPLIER) + _i;
+}
+
+#define TEST_FUZZ_CASE_OPEN(TAG, RUNS)      \
+    {                                       \
+        for(uint64_t _i=0; _i<(RUNS); _i++) \
+        {                                   \
+            TEST_CASE_OPEN_TIMEOUT(tag_fuzz_get(TAG, _i), 0)    \
             {
 
 #define TEST_FUZZ_CASE_CLOSE    \
@@ -135,12 +151,12 @@ static bool start_case(uint64_t __tag, uint64_t line, const char func[], bool sh
     }
 
 [[maybe_unused]]
-static pid_t start_revert(uint64_t __tag, uint64_t line, const char func[])
+static pid_t start_revert(uint64_t _tag, uint64_t line, const char func[])
 {
     pid_t pid = fork();
     if(pid < 0)
     {
-        test_log_error(__tag, line, func, "ERROR FORKING");
+        test_log_error(_tag, func, line, "ERROR FORKING");
     }
     if(pid)
     {
@@ -148,7 +164,7 @@ static pid_t start_revert(uint64_t __tag, uint64_t line, const char func[])
         waitpid_safe(pid, &status);
         if(status == EXIT_SUCCESS)
         {
-            test_log_error(__tag, line, func, "TEST EXPECTED TO REVERT BUT DIDN'T");
+            test_log_error(_tag, func, line, "TEST EXPECTED TO REVERT BUT DIDN'T");
         }
     }
     else
@@ -167,15 +183,15 @@ static pid_t start_revert(uint64_t __tag, uint64_t line, const char func[])
     return pid;
 }
 
-#define TEST_REVERT_OPEN                                    \
-    {                                                       \
-        if(start_revert(__tag, __LINE__, __func__) == 0)    \
+#define TEST_REVERT_OPEN                                \
+    {                                                   \
+        if(start_revert(_tag, __LINE__, __func__) == 0) \
         {
 
 #define TEST_REVERT_CLOSE       \
             exit(EXIT_SUCCESS); \
         }                       \
-        __test_memory = false;  \
+        _test_memory = false;  \
     }
 
 #define ARG_OPEN(...) __VA_ARGS__

--- a/time.h
+++ b/time.h
@@ -30,4 +30,10 @@ static uint64_t get_time(void)
     return (uint64_t)time.tv_sec * 1000000000ULL + (uint64_t)time.tv_nsec;
 }
 
+__attribute__((unused)) 
+static double dtime(uint64_t t)
+{
+    return (double)t / 1e9;
+}
+
 #endif

--- a/time.h
+++ b/time.h
@@ -22,7 +22,7 @@
     #define CLU_CLOCK_ID CLOCK_MONOTONIC
 #endif
 
-__attribute__((unused)) 
+[[nodiscard, maybe_unused]] 
 static uint64_t get_time(void)
 {
     struct timespec time;
@@ -30,7 +30,7 @@ static uint64_t get_time(void)
     return (uint64_t)time.tv_sec * 1000000000ULL + (uint64_t)time.tv_nsec;
 }
 
-__attribute__((unused)) 
+[[maybe_unused]] 
 static double dtime(uint64_t t)
 {
     return (double)t / 1e9;

--- a/time.h
+++ b/time.h
@@ -31,7 +31,7 @@ static uint64_t get_time()
 }
 
 [[nodiscard, maybe_unused]]
-static double dtime(uint64_t t) [[unsequenced]]
+static double dtime(uint64_t t)
 {
     return (double)t / 1e9;
 }

--- a/time.h
+++ b/time.h
@@ -16,21 +16,21 @@
     uint64_t TIME_VAR = _time_end - _time_begin;    \
     _time_begin = _time_end;
 
-#if defined(__linux__)
+#ifdef __linux__
     #define CLU_CLOCK_ID CLOCK_MONOTONIC_RAW
-#elif defined(__APPLE__)
+#elifdef __APPLE__
     #define CLU_CLOCK_ID CLOCK_MONOTONIC
 #endif
 
 [[nodiscard, maybe_unused]]
-static uint64_t get_time(void)
+static uint64_t get_time()
 {
     struct timespec time;
     clock_gettime(CLU_CLOCK_ID, &time);
     return (uint64_t)time.tv_sec * 1000000000ULL + (uint64_t)time.tv_nsec;
 }
 
-[[maybe_unused]]
+[[nodiscard, maybe_unused, unsequenced]]
 static double dtime(uint64_t t)
 {
     return (double)t / 1e9;

--- a/time.h
+++ b/time.h
@@ -30,8 +30,8 @@ static uint64_t get_time()
     return (uint64_t)time.tv_sec * 1000000000ULL + (uint64_t)time.tv_nsec;
 }
 
-[[nodiscard, maybe_unused, unsequenced]]
-static double dtime(uint64_t t)
+[[nodiscard, maybe_unused]]
+static double dtime(uint64_t t) [[unsequenced]]
 {
     return (double)t / 1e9;
 }

--- a/time.h
+++ b/time.h
@@ -22,7 +22,7 @@
     #define CLU_CLOCK_ID CLOCK_MONOTONIC
 #endif
 
-[[nodiscard, maybe_unused]] 
+[[nodiscard, maybe_unused]]
 static uint64_t get_time(void)
 {
     struct timespec time;
@@ -30,7 +30,7 @@ static uint64_t get_time(void)
     return (uint64_t)time.tv_sec * 1000000000ULL + (uint64_t)time.tv_nsec;
 }
 
-[[maybe_unused]] 
+[[maybe_unused]]
 static double dtime(uint64_t t)
 {
     return (double)t / 1e9;

--- a/time.h
+++ b/time.h
@@ -7,8 +7,9 @@
 
 #define TIME_RESET _time_begin = get_time();
 
-#define TIME_SETUP                      \
-    uint64_t _time_begin, _time_end;    \
+#define TIME_SETUP          \
+    uint64_t _time_begin;   \
+    uint64_t _time_end;     \
     TIME_RESET
 
 #define TIME_END(TIME_VAR)                          \
@@ -27,13 +28,15 @@ static uint64_t get_time()
 {
     struct timespec time;
     clock_gettime(CLU_CLOCK_ID, &time);
-    return ((uint64_t)time.tv_sec * 1000000000ULL) + (uint64_t)time.tv_nsec;
+    constexpr uint64_t nanoseconds_per_second = 1'000'000'000;
+    return ((uint64_t)time.tv_sec * nanoseconds_per_second) + (uint64_t)time.tv_nsec;
 }
 
 [[nodiscard, maybe_unused]]
 static double dtime(uint64_t t)
 {
-    return (double)t / 1e9;
+    constexpr uint64_t nanoseconds_per_second = 1'000'000'000;
+    return (double)t / nanoseconds_per_second;
 }
 
 #endif

--- a/time.h
+++ b/time.h
@@ -9,9 +9,8 @@ constexpr uint64_t nanosecs_in_sec = 1'000'000'000;
 
 #define TIME_RESET _time_begin = get_time();
 
-#define TIME_SETUP          \
-    uint64_t _time_begin;   \
-    uint64_t _time_end;     \
+#define TIME_SETUP                      \
+    uint64_t _time_begin, _time_end;    \
     TIME_RESET
 
 #define TIME_END(TIME_VAR)                          \
@@ -36,7 +35,7 @@ static uint64_t get_time()
 [[nodiscard, maybe_unused]]
 static double dtime(uint64_t t)
 {
-    return (double)t / 1e9;
+    return (double)t / nanosecs_in_sec;
 }
 
 #endif

--- a/time.h
+++ b/time.h
@@ -30,19 +30,13 @@ static uint64_t get_time()
 {
     struct timespec time;
     clock_gettime(CLU_CLOCK_ID, &time);
-<<<<<<< HEAD
     return ((uint64_t)time.tv_sec * nanosecs_in_sec) + (uint64_t)time.tv_nsec;
-=======
-    constexpr uint64_t nanoseconds_per_second = 1'000'000'000;
-    return ((uint64_t)time.tv_sec * nanoseconds_per_second) + (uint64_t)time.tv_nsec;
->>>>>>> origin/v3.3
 }
 
 [[nodiscard, maybe_unused]]
 static double dtime(uint64_t t)
 {
-    constexpr uint64_t nanoseconds_per_second = 1'000'000'000;
-    return (double)t / nanoseconds_per_second;
+    return (double)t / 1e9;
 }
 
 #endif

--- a/time.h
+++ b/time.h
@@ -3,7 +3,7 @@
 
 #include <time.h>
 
-#include "uint.h"
+#include "uint.h" // IWYU pragma: keep
 
 #define TIME_RESET _time_begin = get_time();
 
@@ -27,7 +27,7 @@ static uint64_t get_time()
 {
     struct timespec time;
     clock_gettime(CLU_CLOCK_ID, &time);
-    return (uint64_t)time.tv_sec * 1000000000ULL + (uint64_t)time.tv_nsec;
+    return ((uint64_t)time.tv_sec * 1000000000ULL) + (uint64_t)time.tv_nsec;
 }
 
 [[nodiscard, maybe_unused]]

--- a/time.h
+++ b/time.h
@@ -5,10 +5,13 @@
 
 #include "uint.h" // IWYU pragma: keep
 
+constexpr uint64_t nanosecs_in_sec = 1'000'000'000;
+
 #define TIME_RESET _time_begin = get_time();
 
-#define TIME_SETUP                      \
-    uint64_t _time_begin, _time_end;    \
+#define TIME_SETUP          \
+    uint64_t _time_begin;   \
+    uint64_t _time_end;     \
     TIME_RESET
 
 #define TIME_END(TIME_VAR)                          \
@@ -27,7 +30,7 @@ static uint64_t get_time()
 {
     struct timespec time;
     clock_gettime(CLU_CLOCK_ID, &time);
-    return ((uint64_t)time.tv_sec * 1000000000ULL) + (uint64_t)time.tv_nsec;
+    return ((uint64_t)time.tv_sec * nanosecs_in_sec) + (uint64_t)time.tv_nsec;
 }
 
 [[nodiscard, maybe_unused]]

--- a/uint.h
+++ b/uint.h
@@ -5,8 +5,8 @@
 #include <inttypes.h>
 
 typedef uint64_t * uint64_p;
-typedef __uint128_t uint128_t;
-typedef __int128_t int128_t;
+typedef unsigned _BitInt(128) uint128_t;
+typedef signed _BitInt(128) int128_t;
 
 #define U64(VALUE) ((uint64_t)(VALUE))
 #define U128(V) ((uint128_t)(V))
@@ -18,9 +18,9 @@ typedef __int128_t int128_t;
 #define B(BITS) (1UL << (BITS))
 #define B128(BITS) (U128(1UL) << (BITS))
 
-#define UINT128_MAX U128HL(UINT64_MAX, UINT64_MAX)
-#define INT128_MAX I128(U128HL(UINT64_MAX / 2, UINT64_MAX))
-#define INT128_MIN I128(U128HL(B(63), 0))
+constexpr uint128_t UINT128_MAX = ~U128(0);
+constexpr int128_t INT128_MAX = I128(UINT128_MAX >> 1);
+constexpr int128_t INT128_MIN = I128(U128(1) << 127);
 
 #define D64P(C) "%" #C PRIi64
 #define U64P(C) "%" #C PRIu64

--- a/uint.h
+++ b/uint.h
@@ -19,7 +19,9 @@ typedef signed _BitInt(128) int128_t;
 #define B128(BITS) (U128(1) << (BITS))
 
 constexpr uint128_t UINT128_MAX = ~U128(0);
+[[maybe_unused]]
 constexpr int128_t INT128_MAX = I128(UINT128_MAX >> 1);
+[[maybe_unused]]
 constexpr int128_t INT128_MIN = I128(U128(1) << 127);
 
 #define D64P(C) "%" #C PRIi64

--- a/uint.h
+++ b/uint.h
@@ -8,15 +8,15 @@ typedef uint64_t * uint64_p;
 typedef unsigned _BitInt(128) uint128_t;
 typedef signed _BitInt(128) int128_t;
 
-#define U64(VALUE) ((uint64_t)(VALUE))
+#define U64(V) ((uint64_t)(V))
 #define U128(V) ((uint128_t)(V))
 #define I128(V) ((int128_t)(V))
 #define U128HL(V1, V2) ((U128(V1) << 64) | (V2))
-#define MUL(V1, V2) U128(V1) * U128(V2)
+#define MUL(V1, V2) (U128(V1) * U128(V2))
 #define LOW(V) U64(V)
 #define HIGH(V) U64((V) >> 64)
-#define B(BITS) (1UL << (BITS))
-#define B128(BITS) (U128(1UL) << (BITS))
+#define B(BITS) (1ULL << (BITS))
+#define B128(BITS) (U128(1) << (BITS))
 
 constexpr uint128_t UINT128_MAX = ~U128(0);
 constexpr int128_t INT128_MAX = I128(UINT128_MAX >> 1);
@@ -26,7 +26,7 @@ constexpr int128_t INT128_MIN = I128(U128(1) << 127);
 #define U64P(C) "%" #C PRIu64
 #define U64PX "%016" PRIx64
 
-#define U128PX U64P U64P
+#define U128PX U64PX U64PX
 #define U128A(C) HIGH(C), LOW(C)
 
 #endif

--- a/uint.h
+++ b/uint.h
@@ -15,7 +15,7 @@ typedef signed _BitInt(128) int128_t;
 #define MUL(V1, V2) (U128(V1) * U128(V2))
 #define LOW(V) U64(V)
 #define HIGH(V) U64((V) >> 64)
-#define B(BITS) (1ULL << (BITS))
+#define B(BITS) (U64(1) << (BITS))
 #define B128(BITS) (U128(1) << (BITS))
 
 constexpr uint128_t UINT128_MAX = ~U128(0);

--- a/uint.h
+++ b/uint.h
@@ -15,7 +15,7 @@ typedef signed _BitInt(128) int128_t;
 #define MUL(V1, V2) (U128(V1) * U128(V2))
 #define LOW(V) U64(V)
 #define HIGH(V) U64((V) >> 64)
-#define B(BITS) (U64(1) << (BITS))
+#define B(BITS) (1ULL << (BITS))
 #define B128(BITS) (U128(1) << (BITS))
 
 constexpr uint128_t UINT128_MAX = ~U128(0);


### PR DESCRIPTION
This PR modernizes the codebase to use standard C23 features, dropping compiler-specific extensions to improve portability and static analysis compatibility.

**Key Changes:**
* **C23 Attributes:** Replaced legacy `__attribute__((...))` with standard `[[nodiscard]]`, `[[maybe_unused]]`, and `[[noreturn]]`.
* **Modern Types:** Migrated from GCC-specific `__uint128_t` to standard `_BitInt(128)` and introduced `constexpr`.
* **Assertions:** Streamlined the custom `assert` macro while preserving the `0xDEAD` sanitizer trap.
* **Tooling & Cleanups:** Modernized conditional includes (`#elifdef`), standard library fallbacks, and added `IWYU` pragmas.